### PR TITLE
Create a function that returns all ancestors of a PR.

### DIFF
--- a/core/branch.go
+++ b/core/branch.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 
@@ -136,6 +137,26 @@ func (b *LocalPr) GetAncestor() (Branch, error) {
 func (b *LocalPr) SetAncestor(branch Branch) {
 	b.state.Ancestor.Name = branch.LocalName()
 	b.saveState()
+}
+
+// Returns all ancestor but not itself.
+func (b *LocalPr) AllAncestors() []*LocalPr {
+	all := b.allAncestors(make([]*LocalPr, 0))[1:]
+	slices.Reverse(all)
+	return all
+}
+
+func (b *LocalPr) allAncestors(descendents []*LocalPr) []*LocalPr {
+	descendents = append(descendents, b)
+	ancestor, err := b.GetAncestor()
+	if err != nil {
+		return descendents
+	}
+	ancestorPr, ok := ancestor.(*LocalPr)
+	if !ok {
+		return descendents
+	}
+	return ancestorPr.allAncestors(descendents)
 }
 
 func (b *LocalPr) LocalBranch() string {

--- a/core/github.go
+++ b/core/github.go
@@ -10,6 +10,8 @@ import (
 type GhPullRequest interface {
 	List(ctx context.Context, owner string, repo string, opt *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error)
 	Create(ctx context.Context, owner string, repo string, pull *github.NewPullRequest) (*github.PullRequest, *github.Response, error)
+	Get(ctx context.Context, owner string, repo string, number int) (*github.PullRequest, *github.Response, error)
+	Merge(ctx context.Context, owner string, repo string, number int, commitMessage string, options *github.PullRequestOptions) (*github.PullRequestMergeResult, *github.Response, error)
 }
 
 type GithubClient struct {

--- a/core/tests/testrepo.go
+++ b/core/tests/testrepo.go
@@ -78,10 +78,10 @@ func (r *TestRepo) PrepareSource() {
 	if err != nil {
 		panic(err)
 	}
-	wt.Add("2")
-	wt.Commit("2", &git.CommitOptions{})
-	wt.Add("3")
-	wt.Commit("3", &git.CommitOptions{})
+	for i := 0; i < 5; i++ {
+		wt.Add(strconv.Itoa(i))
+		wt.Commit(strconv.Itoa(i), &git.CommitOptions{})
+	}
 }
 
 func (r *TestRepo) AssertHasPr(t *testing.T, n int) *core.LocalPr {

--- a/core/tests/testrepo.go
+++ b/core/tests/testrepo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 	"testing"
 
 	"github.com/cupcicm/opp/cmd"
@@ -118,6 +119,16 @@ func (m *GithubMock) Create(ctx context.Context, owner string, repo string, pull
 	return args.Get(0).(*github.PullRequest), nil, args.Error(2)
 }
 
+func (m *GithubMock) Get(ctx context.Context, owner string, repo string, number int) (*github.PullRequest, *github.Response, error) {
+	args := m.Mock.Called(ctx, owner, repo, number)
+	return args.Get(0).(*github.PullRequest), nil, args.Error(2)
+}
+
+func (m *GithubMock) Merge(ctx context.Context, owner string, repo string, number int, commitMessage string, options *github.PullRequestOptions) (*github.PullRequestMergeResult, *github.Response, error) {
+	args := m.Mock.Called(ctx, owner, repo, number, commitMessage, options)
+	return args.Get(0).(*github.PullRequestMergeResult), nil, args.Error(2)
+}
+
 func (m *GithubMock) CallListAndReturnPr(prNumber int) {
 	pr := github.PullRequest{
 		Number: &prNumber,
@@ -132,6 +143,18 @@ func (m *GithubMock) CallCreate(prNumber int) {
 		Number: &prNumber,
 	}
 	m.On("Create", mock.Anything, "cupcicm", "opp", mock.Anything).Return(
+		&pr, nil, nil,
+	).Once()
+}
+
+func (m *GithubMock) CallGetAndReturnMergeable(prNumber int, mergeable bool) {
+	reason := "dirty"
+	pr := github.PullRequest{
+		Number:         &prNumber,
+		Mergeable:      &mergeable,
+		MergeableState: &reason,
+	}
+	m.On("Get", mock.Anything, "cupcicm", "opp", prNumber).Return(
 		&pr, nil, nil,
 	).Once()
 }

--- a/opp.go
+++ b/opp.go
@@ -21,7 +21,8 @@ func main() {
 	viper.SetConfigType("yaml")
 	viper.ReadInConfig()
 	root := cobra.Command{
-		Use: "opp",
+		Use:          "opp",
+		SilenceUsage: true,
 	}
 	ctx := CommandContext()
 	root.AddCommand(cmd.InitCommand(repo))


### PR DESCRIPTION
Walks back the dependency chain to the main branch.