### PR TITLE
fix: handle github repo without .git suffix in init command

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -71,7 +71,11 @@ func extractGithubRepo(r *core.Repo) (string, string) {
 				panic("two github remotes in this repo.")
 			}
 			found = true
-			result = url[index+len("github.com")+1 : dotGit]
+			if dotGit == -1 {
+				result = url[index+len("github.com")+1:]
+			} else {
+				result = url[index+len("github.com")+1 : dotGit]
+			}
 			remoteName = remote.Config().Name
 		}
 	}

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -134,7 +134,7 @@ func (c *createPr) createOnce(ctx context.Context, hash plumbing.Hash, ancestor 
 	}
 	pr, _, err := c.PullRequests.Create(
 		ctx,
-		core.GetGithubUsername(),
+		core.GetGithubOwner(),
 		core.GetGithubRepoName(),
 		&pull,
 	)

--- a/cmd/rebase.go
+++ b/cmd/rebase.go
@@ -28,9 +28,12 @@ func RebaseCommand(repo *core.Repo) *cobra.Command {
 			if !repo.NoLocalChanges() {
 				return errors.New("there are uncommitted changes. Cannot run rebase")
 			}
-			_, err := rebase(cmd.Context(), repo, pr, true)
-			repo.Checkout(pr)
-			return err
+			branch, err := rebase(cmd.Context(), repo, pr, true)
+			if err != nil {
+				return err
+			}
+			repo.Checkout(branch)
+			return nil
 		},
 	}
 	return cmd
@@ -72,8 +75,8 @@ func rebase(ctx context.Context, repo *core.Repo, pr *core.LocalPr, first bool) 
 			// PR has been merged : the local branch is now part
 			// of the history of the main branch.
 			repo.CleanupAfterMerge(ctx, pr)
+			return baseBranch, nil
 		}
 	}
-
-	return baseBranch, nil
+	return pr, nil
 }


### PR DESCRIPTION
Also fixes a problem when you don't own the repo.