### PR TITLE
Make fetch prune the local branches.

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -102,10 +102,10 @@ func (m *merger) Merge(ctx context.Context, prs ...*core.LocalPr) error {
 			return fmt.Errorf("did not merge %s", pr.LocalBranch())
 		}
 		if err == nil {
-			fmt.Printf("(✅)\n")
+			fmt.Printf("✅\n")
 			m.Repo.CleanupAfterMerge(ctx, pr)
 		} else {
-			fmt.Printf("(❌ - %s)\n", err)
+			fmt.Printf("❌ (%s)\n", err)
 		}
 	}
 	return nil

--- a/core/repo.go
+++ b/core/repo.go
@@ -187,18 +187,9 @@ func (r *Repo) GitExec(format string, args ...any) *exec.Cmd {
 }
 
 func (r *Repo) Fetch(ctx context.Context) error {
-	err := r.FetchContext(ctx, &git.FetchOptions{
-		RemoteName: GetRemoteName(),
-	})
-
-	if err == git.NoErrAlreadyUpToDate {
-		return nil
-	}
-	return err
+	cmd := r.GitExec("fetch -p %s", GetRemoteName())
+	return cmd.Run()
 }
-
-func (r *Repo) Rebase(ctx context.Context, branch Branch) error {
-	cmd := r.GitExec("rebase %s/%s", GetRemoteName(), branch.RemoteName())
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
- git fetch doesn't delete the branches that don't exist on the
remote anymore for some reason.
- git fetch -p does, but is not implemented in go-git.