### PR TITLE
Make rebase work a lot better with dependant changes.

### DIFF
--- a/cmd/rebase.go
+++ b/cmd/rebase.go
@@ -28,33 +28,77 @@ func RebaseCommand(repo *core.Repo) *cobra.Command {
 			if !repo.NoLocalChanges() {
 				return errors.New("there are uncommitted changes. Cannot run rebase")
 			}
-			branch, err := rebase(cmd.Context(), repo, pr, true)
+			hasBeenMerged, err := rebase(cmd.Context(), repo, pr, true)
 			if err != nil {
 				return err
 			}
-			repo.Checkout(branch)
+			if hasBeenMerged {
+				repo.Checkout(repo.BaseBranch())
+			} else {
+				repo.Checkout(pr)
+			}
 			return nil
 		},
 	}
 	return cmd
 }
 
-func rebase(ctx context.Context, repo *core.Repo, pr *core.LocalPr, first bool) (core.Branch, error) {
-	ancestor, err := pr.GetAncestor()
-	var baseBranch core.Branch = ancestor
-	if err != nil {
-		return nil, err
-	}
-	if ancestor.IsPr() {
-		baseBranch, err = rebase(ctx, repo, ancestor.(*core.LocalPr), false)
-		if err != nil {
-			return nil, err
-		}
-	}
-	_, err = repo.GetLocalTip(pr)
+// Return true when the current PR has been merged and does not actually exist anymore.
+func rebase(ctx context.Context, repo *core.Repo, pr *core.LocalPr, first bool) (bool, error) {
+	_, err := repo.GetLocalTip(pr)
 	if err == plumbing.ErrReferenceNotFound {
 		// The branch has been merged and deleted.
 		repo.CleanupAfterMerge(ctx, pr)
+		return true, nil
+	}
+
+	ancestor, err := pr.GetAncestor()
+	if err != nil {
+		return false, err
+	}
+
+	if ancestor.IsPr() {
+		return rebaseOnDependentPr(ctx, repo, pr, ancestor.(*core.LocalPr), first)
+	} else {
+		return rebaseOnBaseBranch(ctx, repo, pr, first)
+	}
+}
+
+// Return true when the current PR has been merged and does not actually exist anymore.
+func rebaseOnBaseBranch(ctx context.Context, repo *core.Repo, pr *core.LocalPr, first bool) (bool, error) {
+	if !first {
+		fmt.Printf("Rebasing dependent PR %s...\n", pr.LocalBranch())
+	}
+
+	if err := repo.Checkout(pr); err != nil {
+		return false, fmt.Errorf("error during checkout: %w", err)
+	}
+	if err := repo.Rebase(ctx, repo.BaseBranch(), true); err != nil {
+		return false, fmt.Errorf("error during rebase: %w", err)
+	}
+	remoteBaseBranchTip := core.Must(repo.GetRemoteTip(repo.BaseBranch()))
+	localPrTip := core.Must(repo.GetLocalTip(pr))
+	if core.Must(localPrTip.IsAncestor(remoteBaseBranchTip)) {
+		// PR has been merged : the local branch is now part
+		// of the history of the main branch.
+		repo.CleanupAfterMerge(ctx, pr)
+		return true, nil
+	}
+	return false, nil
+}
+
+// The strategy here is: try to rebase silently.
+// If it works, great. If not, run an interactive rebase because
+// if the dependant branch has been modified git doesn't know where
+// the current PR starts exactly. The user will know.
+// Return true when the current PR has been merged and does not actually exist anymore.
+func rebaseOnDependentPr(ctx context.Context, repo *core.Repo, pr *core.LocalPr, ancestor *core.LocalPr, first bool) (bool, error) {
+	hasBeenMerged, err := rebase(ctx, repo, ancestor, false)
+	if err != nil {
+		return false, err
+	}
+	if hasBeenMerged {
+		return rebaseOnBaseBranch(ctx, repo, pr, first)
 	}
 
 	if !first {
@@ -63,20 +107,18 @@ func rebase(ctx context.Context, repo *core.Repo, pr *core.LocalPr, first bool) 
 		fmt.Println()
 	}
 	if err := repo.Checkout(pr); err != nil {
-		return nil, fmt.Errorf("error during checkout: %w", err)
+		return false, fmt.Errorf("error during checkout: %w", err)
 	}
-	if err := repo.Rebase(ctx, ancestor); err != nil {
-		return nil, fmt.Errorf("error during rebase: %w", err)
-	}
-	if !ancestor.IsPr() {
-		remoteBaseBranchTip := core.Must(repo.GetRemoteTip(ancestor))
-		localPrTip := core.Must(repo.GetLocalTip(pr))
-		if core.Must(localPrTip.IsAncestor(remoteBaseBranchTip)) {
-			// PR has been merged : the local branch is now part
-			// of the history of the main branch.
-			repo.CleanupAfterMerge(ctx, pr)
-			return baseBranch, nil
+	// Try to rebase silently once.
+	if !repo.TryRebaseSilently(ctx, ancestor) {
+		fmt.Printf("%s cannot be cleanly rebased on top of %s.\n", pr.LocalBranch(), ancestor.LocalBranch())
+		fmt.Printf("This usually happens when you modified (e.g. amended) some commits in %s.\n", ancestor.LocalBranch())
+		fmt.Printf("Here is an editor window where you need to pick only the commits in %s.\n", pr.LocalBranch())
+		fmt.Printf("Please delete all lines that represent commits in %s\n", ancestor.LocalBranch())
+		err := repo.InteractiveRebase(ctx, ancestor)
+		if err != nil {
+			return false, errors.New("please finish the interactive rebase then re-run")
 		}
 	}
-	return pr, nil
+	return false, nil
 }


### PR DESCRIPTION
If a PR B depends on PR A and you git commit --amend a commit in PR A
then git rebase will not know anymore whether PR B should contain the
new or the old version, and a git rebase will conflict between those
two.
Use this to our advantage : try to rebase silently, and if that rebase
fails, hope that it's because of that problem and let the user check
that all the commits are actually part of PR B.