### PR TITLE
Use a context in almost all git exec commands.

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -114,7 +114,7 @@ func (c *create) SanitizeArgs(cCtx *cli.Context) (*args, error) {
 		return nil, err
 	}
 	overrideAncestor := cCtx.String("base")
-	localChanges := !c.Repo.NoLocalChanges()
+	localChanges := !c.Repo.NoLocalChanges(cCtx.Context)
 	if overrideAncestor != "" {
 		overrideAncestorBranch, err = c.Repo.GetBranch(overrideAncestor)
 		needsRebase = true

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -1,6 +1,7 @@
 package cmd_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -25,7 +26,7 @@ func TestCanCreatePRWhenNotOnBranch(t *testing.T) {
 	r := tests.NewTestRepo(t)
 
 	// Go in detached HEAD mode.
-	r.Repo.GitExec("checkout %s", "HEAD^^").Run()
+	r.Repo.GitExec(context.Background(), "checkout %s", "HEAD^^").Run()
 	fmt.Println("after")
 
 	localPr := r.CreatePr(t, "HEAD", 2)

--- a/cmd/rebase.go
+++ b/cmd/rebase.go
@@ -26,7 +26,7 @@ func RebaseCommand(repo *core.Repo) *cli.Command {
 			if err := repo.Fetch(cCtx.Context); err != nil {
 				return cli.Exit(fmt.Errorf("error during fetch: %w", err), 1)
 			}
-			if !repo.NoLocalChanges() {
+			if !repo.NoLocalChanges(cCtx.Context) {
 				return cli.Exit("there are uncommitted changes. Cannot run rebase", 1)
 			}
 			hasBeenMerged, err := rebase(cCtx.Context, repo, pr, true)

--- a/core/tests/testrepo.go
+++ b/core/tests/testrepo.go
@@ -88,8 +88,8 @@ func (r *TestRepo) Commit(msg string) plumbing.Hash {
 }
 
 func (r *TestRepo) PrepareSource() {
-	r.GitExec("config user.email test@robot.com").Run()
-	r.GitExec("config user.name Robot").Run()
+	r.GitExec(context.Background(), "config user.email test@robot.com").Run()
+	r.GitExec(context.Background(), "config user.name Robot").Run()
 	for i := 0; i < 10; i++ {
 		os.WriteFile(path.Join(r.Path(), fmt.Sprint(i)), []byte(fmt.Sprint(i)), 0644)
 	}


### PR DESCRIPTION
Except for Checkout() that really shouldn't take long.