### PR TITLE
Fix hyperlink.

### DIFF
--- a/cmd/push.go
+++ b/cmd/push.go
@@ -52,7 +52,7 @@ func push(ctx context.Context, repo *core.Repo, pr *core.LocalPr) error {
 			return err
 		}
 	}
-	fmt.Printf("Pushing local changes to %s...", pr.Url())
+	fmt.Printf("Pushing local changes to %s ...", pr.Url())
 	err = pr.Push(ctx)
 	if err == nil {
 		fmt.Println("  ✅")


### PR DESCRIPTION
When the dots are close to the URL, ctrl clicking puts them in the URL.