### PR TITLE
Makes opp run `opp-xxx.sh` scripts when no command match.

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -2,7 +2,12 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/cupcicm/opp/core"
 	"github.com/urfave/cli/v2"
@@ -20,5 +25,25 @@ func MakeApp(out io.Writer, repo *core.Repo, gh func(context.Context) core.GhPul
 			RebaseCommand(repo),
 			PushCommand(repo),
 		},
+		Action: func(ctx *cli.Context) error {
+			// Called only if no subcommand match.
+			args := ctx.Args()
+			if !args.Present() {
+				return errors.New("no subcommand provided")
+			}
+			subcommand := args.First()
+			return runCustomScript(ctx.Context, subcommand, args.Slice()[1:])
+		},
 	}
+}
+
+// Much like git, if no valid subcommand match, run `opp-XXX.sh` instead.
+// This allows the user to create new opp commands.
+func runCustomScript(ctx context.Context, subcommand string, args []string) error {
+	subcommand = fmt.Sprintf("opp-%s.sh %s", subcommand, strings.Join(args, " "))
+	cmd := exec.CommandContext(ctx, "bash", "-c", subcommand)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }


### PR DESCRIPTION
The script needs to be in the user's path. This allows the user to
customize opp / create new commands.