### PR TITLE
Add support for draft PRS

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 
 	"github.com/cupcicm/opp/core"
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v56/github"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v56/github"
 	"github.com/urfave/cli/v2"
 )
 

--- a/core/github.go
+++ b/core/github.go
@@ -3,7 +3,7 @@ package core
 import (
 	"context"
 
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v56/github"
 	"golang.org/x/oauth2"
 )
 

--- a/core/tests/testrepo.go
+++ b/core/tests/testrepo.go
@@ -14,7 +14,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/google/go-github/github"
+	"github.com/google/go-github/v56/github"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/go-git/go-git/v5 v5.8.1
-	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/go-github/v56 v56.0.0
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.3
 	github.com/urfave/cli/v2 v2.25.7

--- a/go.sum
+++ b/go.sum
@@ -139,8 +139,8 @@ github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
-github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
+github.com/google/go-github/v56 v56.0.0 h1:TysL7dMa/r7wsQi44BjqlwaHvwlFlqkK8CtBWCX3gb4=
+github.com/google/go-github/v56 v56.0.0/go.mod h1:D8cdcX98YWJvi7TLo7zM4/h8ZTx6u6fwGEkCdisopo0=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=


### PR DESCRIPTION
Add support for draft PRs.

Note that this required upgrading to a more recent version of go-github. Although the draft functionality has been available since 2019, I took the opportunity to upgrade to the latest version.