### PR TITLE
[Refactor] Adds the option to access the Issues API

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -13,7 +13,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func MakeApp(out io.Writer, repo *core.Repo, gh func(context.Context) core.GhPullRequest) *cli.App {
+func MakeApp(out io.Writer, repo *core.Repo, gh func(context.Context) core.Gh) *cli.App {
 	return &cli.App{
 		Name:  "opp",
 		Usage: "Create, update and merge Github pull requests from the command line.",

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -9,7 +9,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func CleanCommand(repo *core.Repo, gh func(context.Context) core.GhPullRequest) *cli.Command {
+func CleanCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Command {
 	cmd := &cli.Command{
 		Name:        "clean",
 		Aliases:     []string{"gc"},
@@ -18,7 +18,7 @@ func CleanCommand(repo *core.Repo, gh func(context.Context) core.GhPullRequest) 
 			repo.Fetch(cCtx.Context)
 			localPrs := repo.AllPrs(cCtx.Context)
 			for _, pr := range localPrs {
-				pullRequests := gh(cCtx.Context)
+				pullRequests := gh(cCtx.Context).PullRequests()
 				_, err := repo.GetRemoteTip(&pr)
 				if errors.Is(err, plumbing.ErrReferenceNotFound) {
 					// The remote tip does not exist anymore : it has been deleted on the github repo.

--- a/cmd/clean_test.go
+++ b/cmd/clean_test.go
@@ -33,7 +33,7 @@ func TestCleanupCleansDependencies(t *testing.T) {
 	pr3 := r.CreatePr(t, "HEAD", 3)
 
 	r.DeleteRemoteBranch(context.Background(), pr2)
-	r.GithubMock.CallGetAndReturnMergeable(3, true)
+	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeable(3, true)
 
 	assert.Nil(t, r.Run("clean"))
 

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -18,7 +18,7 @@ type merger struct {
 	PullRequests core.GhPullRequest
 }
 
-func MergeCommand(repo *core.Repo, gh func(context.Context) core.GhPullRequest) *cli.Command {
+func MergeCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Command {
 	cmd := &cli.Command{
 		Name:    "merge",
 		Aliases: []string{"m"},
@@ -50,7 +50,7 @@ func MergeCommand(repo *core.Repo, gh func(context.Context) core.GhPullRequest) 
 					}
 				}
 			}
-			merger := merger{Repo: repo, PullRequests: gh(cCtx.Context)}
+			merger := merger{Repo: repo, PullRequests: gh(cCtx.Context).PullRequests()}
 			ancestors := pr.AllAncestors()
 			mergeContext, cancel := context.WithTimeoutCause(
 				cCtx.Context, core.GetGithubTimeout(),

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -15,8 +15,8 @@ func TestCannotMergeIfDependentPRs(t *testing.T) {
 	pr3 := r.CreatePr(t, "HEAD", 3)
 	r.Repo.Checkout(pr3)
 
-	r.GithubMock.CallGetAndReturnMergeable(2, true)
-	r.GithubMock.CallGetAndReturnMergeable(3, true)
+	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeable(2, true)
+	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeable(3, true)
 
 	assert.NotNil(t, r.Run("merge"))
 }
@@ -28,8 +28,8 @@ func TestMergeKeepsTrackOfAncestorTips(t *testing.T) {
 	pr3 := r.CreatePr(t, "HEAD", 3)
 	r.Repo.Checkout(pr2)
 
-	r.GithubMock.CallGetAndReturnMergeable(2, true)
-	r.GithubMock.CallMerge(2, "8f4ca5d979bc19b7c836655a6432d690f78316af")
+	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeable(2, true)
+	r.GithubMock.PullRequestsMock.CallMerge(2, "8f4ca5d979bc19b7c836655a6432d690f78316af")
 
 	// Check that pr3 knows about the tip of its ancestor (pr2)
 	assert.Len(t, pr3.AncestorTips(), 1)

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -46,7 +46,7 @@ whether it reached the base branch or the tip of another PR first when walking b
 `)
 )
 
-func PrCommand(repo *core.Repo, gh func(context.Context) core.GhPullRequest) *cli.Command {
+func PrCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Command {
 	cmd := &cli.Command{
 		Name:        "pr",
 		Aliases:     []string{"pull-request", "new"},
@@ -75,7 +75,7 @@ func PrCommand(repo *core.Repo, gh func(context.Context) core.GhPullRequest) *cl
 			},
 		},
 		Action: func(cCtx *cli.Context) error {
-			pr := create{Repo: repo, PullRequests: gh(cCtx.Context)}
+			pr := create{Repo: repo, PullRequests: gh(cCtx.Context).PullRequests()}
 			args, err := pr.SanitizeArgs(cCtx)
 			if err != nil {
 				return err
@@ -106,6 +106,7 @@ func PrCommand(repo *core.Repo, gh func(context.Context) core.GhPullRequest) *cl
 type create struct {
 	Repo         *core.Repo
 	PullRequests core.GhPullRequest
+	Issues       core.GhPullRequest
 }
 
 type args struct {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -19,7 +19,7 @@ type status struct {
 	PullRequests core.GhPullRequest
 }
 
-func StatusCommand(out io.Writer, repo *core.Repo, gh func(context.Context) core.GhPullRequest) *cli.Command {
+func StatusCommand(out io.Writer, repo *core.Repo, gh func(context.Context) core.Gh) *cli.Command {
 	cmd := &cli.Command{
 		Name:    "status",
 		Aliases: []string{"s"},
@@ -27,7 +27,7 @@ func StatusCommand(out io.Writer, repo *core.Repo, gh func(context.Context) core
 			if cCtx.NArg() > 0 {
 				return cli.Exit("too many arguments", 1)
 			}
-			status := status{Out: out, Repo: repo, PullRequests: gh(cCtx.Context)}
+			status := status{Out: out, Repo: repo, PullRequests: gh(cCtx.Context).PullRequests()}
 			repo.Fetch(cCtx.Context)
 			localPrs := repo.AllPrs(cCtx.Context)
 			alreadyMentioned := make(map[int]bool)

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -22,10 +22,10 @@ func TestStatus(t *testing.T) {
 	pr3 := plumbing.NewBranchReferenceName(core.LocalBranchForPr(3))
 	r.Repo.Storer.SetReference(plumbing.NewSymbolicReference(pr4, pr3))
 
-	r.GithubMock.CallGetAndReturnMergeable(2, true)
-	r.GithubMock.CallGetAndReturnMergeable(3, false)
-	r.GithubMock.CallGetAndReturnMergeable(4, true)
-	r.GithubMock.CallGetAndReturnMergeable(5, false)
+	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeable(2, true)
+	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeable(3, false)
+	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeable(4, true)
+	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeable(5, false)
 
 	assert.Nil(t, r.Run("status"))
 	assert.Equal(t, strings.TrimSpace(`

--- a/core/github.go
+++ b/core/github.go
@@ -14,12 +14,25 @@ type GhPullRequest interface {
 	Merge(ctx context.Context, owner string, repo string, number int, commitMessage string, options *github.PullRequestOptions) (*github.PullRequestMergeResult, *github.Response, error)
 }
 
+type GhIssues interface {
+	List(ctx context.Context, all bool, opts *github.IssueListOptions) ([]*github.Issue, *github.Response, error)
+}
+
+type Gh interface {
+	PullRequests() GhPullRequest
+	Issues() GhIssues
+}
+
 type GithubClient struct {
 	*github.Client
 }
 
 func (c *GithubClient) PullRequests() GhPullRequest {
 	return c.Client.PullRequests
+}
+
+func (c *GithubClient) Issues() GhIssues {
+	return c.Client.Issues
 }
 
 func NewClient(ctx context.Context) *GithubClient {

--- a/opp.go
+++ b/opp.go
@@ -17,8 +17,8 @@ func CommandContext() (context.Context, context.CancelCauseFunc) {
 	return context.WithCancelCause(context.Background())
 }
 
-func gh(ctx context.Context) core.GhPullRequest {
-	return core.NewClient(ctx).PullRequests()
+func gh(ctx context.Context) core.Gh {
+	return core.NewClient(ctx)
 }
 
 func main() {


### PR DESCRIPTION
This will be useful soon. Needed a refacto to have an object that
holds the Issues API *and* the PR API at the same time