### PR TITLE
Avoid using issue numbers when creating PRs.

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -362,12 +362,13 @@ func (c *create) undoCreatePr(ctx context.Context, prNumber int) {
 	c.Repo.DeleteRemoteBranch(ctx, pr)
 }
 
+// The Github API list pull requests and issues under "issues".
 func (c *create) getLastPrNumber(ctx context.Context) (int, error) {
-	pr, _, err := c.Github.PullRequests().List(
+	issues, _, err := c.Github.Issues().ListByRepo(
 		ctx,
 		core.GetGithubOwner(),
 		core.GetGithubRepoName(),
-		&github.PullRequestListOptions{
+		&github.IssueListByRepoOptions{
 			State:     "all",
 			Sort:      "created",
 			Direction: "desc",
@@ -380,8 +381,9 @@ func (c *create) getLastPrNumber(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if len(pr) == 0 {
+
+	if len(issues) == 0 {
 		return 0, nil
 	}
-	return *pr[0].Number, nil
+	return *issues[0].Number, nil
 }

--- a/core/github.go
+++ b/core/github.go
@@ -15,7 +15,7 @@ type GhPullRequest interface {
 }
 
 type GhIssues interface {
-	List(ctx context.Context, all bool, opts *github.IssueListOptions) ([]*github.Issue, *github.Response, error)
+	ListByRepo(ctx context.Context, owner string, repo string, opts *github.IssueListByRepoOptions) ([]*github.Issue, *github.Response, error)
 }
 
 type Gh interface {

--- a/core/tests/testrepo.go
+++ b/core/tests/testrepo.go
@@ -137,7 +137,7 @@ func (r *TestRepo) AssertHasPr(t *testing.T, n int) *core.LocalPr {
 }
 
 func (r *TestRepo) CreatePr(t *testing.T, ref string, prNumber int, args ...string) *core.LocalPr {
-	r.GithubMock.PullRequestsMock.CallListAndReturnPr(prNumber - 1)
+	r.GithubMock.IssuesMock.CallListAndReturnPr(prNumber - 1)
 	r.GithubMock.PullRequestsMock.CallCreate(prNumber)
 
 	r.Run("pr", append(args, ref)...)
@@ -193,17 +193,17 @@ func (m *PullRequestsMock) Merge(ctx context.Context, owner string, repo string,
 	args := m.Mock.Called(ctx, owner, repo, number, commitMessage, options)
 	return args.Get(0).(*github.PullRequestMergeResult), nil, args.Error(2)
 }
-func (m *IssuesMock) List(ctx context.Context, all bool, opts *github.IssueListOptions) ([]*github.Issue, *github.Response, error) {
-	args := m.Mock.Called(ctx, all, opts)
+func (m *IssuesMock) ListByRepo(ctx context.Context, owner string, repo string, opts *github.IssueListByRepoOptions) ([]*github.Issue, *github.Response, error) {
+	args := m.Mock.Called(ctx, owner, repo, opts)
 	return args.Get(0).([]*github.Issue), nil, args.Error(2)
 }
 
-func (m *PullRequestsMock) CallListAndReturnPr(prNumber int) {
-	pr := github.PullRequest{
+func (m *IssuesMock) CallListAndReturnPr(prNumber int) {
+	pr := github.Issue{
 		Number: &prNumber,
 	}
-	m.On("List", mock.Anything, "cupcicm", "opp", mock.Anything).Return(
-		[]*github.PullRequest{&pr}, nil, nil,
+	m.On("ListByRepo", mock.Anything, "cupcicm", "opp", mock.Anything).Return(
+		[]*github.Issue{&pr}, nil, nil,
 	).Once()
 }
 


### PR DESCRIPTION
But don't do it the first time to make it faster.