### PR TITLE
Prevent panic when PR creation fails

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -88,15 +88,14 @@ func PrCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Command {
 				args = newArgs
 			}
 
-			err = nil
-			localPr, createErr := pr.Create(cCtx.Context, args)
+			localPr, err := pr.Create(cCtx.Context, args)
+			if err != nil {
+				return err
+			}
 			if args.CheckoutPr {
-				err = repo.Checkout(localPr)
+				return repo.Checkout(localPr)
 			}
-			if createErr != nil {
-				return createErr
-			}
-			return err
+			return nil
 		},
 	}
 


### PR DESCRIPTION
Handle PR-creation failure instead of blindly trying to checkout
a non-existent local PR branch.

Trace from panics that were occurring is as follows:

```
goroutine 1 [running]:
github.com/cupcicm/opp/core.(*LocalPr).LocalBranch(...)
	opp/core/branch.go:197
github.com/cupcicm/opp/core.(*LocalPr).LocalName(0x140000bc000?)
	opp/core/branch.go:110 +0x18
github.com/cupcicm/opp/core.(*Repo).Checkout(0x1400018f8d0?, {0x104c36410?, 0x0?})
	opp/core/repo.go:171 +0x30
github.com/cupcicm/opp/cmd.PrCommand.func1(0x1400009e200)
	opp/cmd/pr.go:94 +0xd0
github.com/urfave/cli/v2.(*Command).Run(0x140001f02c0, 0x1400009e200, {0x1400009c2e0, 0x2, 0x2})
	go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:274 +0x730
github.com/urfave/cli/v2.(*Command).Run(0x140000a4160, 0x1400009e140, {0x14000020150, 0x3, 0x3})
	go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/command.go:267 +0x940
github.com/urfave/cli/v2.(*App).RunContext(0x140001f2000, {0x104c37610?, 0x1400010adc0}, {0x14000020150, 0x3, 0x3})
	go/pkg/mod/github.com/urfave/cli/v2@v2.25.7/app.go:332 +0x518
```