### PR TITLE
Add command to add comments to PRs.

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -26,6 +26,7 @@ func MakeApp(out io.Writer, repo *core.Repo, gh func(context.Context) core.Gh) *
 			StatusCommand(out, repo, gh),
 			RebaseCommand(repo),
 			PushCommand(repo),
+			CommentCommand(repo, gh),
 		},
 		Action: func(ctx *cli.Context) error {
 			// Called only if no subcommand match.

--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"strconv"
-
 	"github.com/cupcicm/opp/core"
 	"github.com/google/go-github/v56/github"
 	"github.com/urfave/cli/v2"
@@ -15,32 +13,24 @@ func CommentCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Comm
 		Name:        "comment",
 		Description: "Add a comment to a PR",
 		Usage:       "Adds a comment to a PR",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  "pr",
-				Usage: "number of the PR on which to add a comment (defaults to current PR branch number)",
-			},
-		},
 		Action: func(cCtx *cli.Context) error {
 
-			if cCtx.NArg() == 0 {
-				return cli.Exit("No comment body supplied", 1)
+			var prParam string
+			var comment string
+			switch cCtx.NArg() {
+			case 1:
+				prParam = ""
+				comment = cCtx.Args().First()
+			case 2:
+				prParam = cCtx.Args().First()
+				comment = cCtx.Args().Get(1)
+			default:
+				return cli.Exit("Usage: opp comment [pr] $comment", 1)
 			}
-			commentBody := cCtx.Args().Get(0)
-			var prNumber int
-			var err error
-			if cCtx.IsSet("pr") {
-				prStr := cCtx.String("pr")
-				prNumber, err = strconv.Atoi(prStr)
-				if err != nil {
-					return cli.Exit(fmt.Sprintf("Invalid pr numnber '%s'", prStr), 1)
-				}
-			} else {
-				pr, found := repo.PrForHead()
-				if !found {
-					return cli.Exit("Can't determine pr number on which to add comment", 1)
-				}
-				prNumber = pr.PrNumber
+
+			pr, _, err := PrFromStringOrCurrentBranch(repo, prParam)
+			if err != nil {
+				return err
 			}
 			ctx, cancel := context.WithTimeoutCause(
 				cCtx.Context, core.GetGithubTimeout(),
@@ -49,11 +39,12 @@ func CommentCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Comm
 			defer cancel()
 
 			_, _, err = gh(cCtx.Context).Issues().CreateComment(ctx, core.GetGithubOwner(),
-				core.GetGithubRepoName(), prNumber, &github.IssueComment{Body: &commentBody})
+				core.GetGithubRepoName(), pr.PrNumber, &github.IssueComment{Body: &comment})
 			if err != nil {
 				PrintFailure(nil)
 				return err
 			}
+			fmt.Printf("Comment added to %s ", pr.Url())
 			PrintSuccess()
 			return nil
 		},

--- a/cmd/comment.go
+++ b/cmd/comment.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/cupcicm/opp/core"
+	"github.com/google/go-github/v56/github"
+	"github.com/urfave/cli/v2"
+)
+
+func CommentCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Command {
+	cmd := &cli.Command{
+		Name:        "comment",
+		Description: "Add a comment to a PR",
+		Usage:       "Adds a comment to a PR",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "pr",
+				Usage: "number of the PR on which to add a comment (defaults to current PR branch number)",
+			},
+		},
+		Action: func(cCtx *cli.Context) error {
+
+			if cCtx.NArg() == 0 {
+				return cli.Exit("No comment body supplied", 1)
+			}
+			commentBody := cCtx.Args().Get(0)
+			var prNumber int
+			var err error
+			if cCtx.IsSet("pr") {
+				prStr := cCtx.String("pr")
+				prNumber, err = strconv.Atoi(prStr)
+				if err != nil {
+					return cli.Exit(fmt.Sprintf("Invalid pr numnber '%s'", prStr), 1)
+				}
+			} else {
+				pr, found := repo.PrForHead()
+				if !found {
+					return cli.Exit("Can't determine pr number on which to add comment", 1)
+				}
+				prNumber = pr.PrNumber
+			}
+			ctx, cancel := context.WithTimeoutCause(
+				cCtx.Context, core.GetGithubTimeout(),
+				fmt.Errorf("adding comment too slow, increase github.timeout"),
+			)
+			defer cancel()
+
+			_, _, err = gh(cCtx.Context).Issues().CreateComment(ctx, core.GetGithubOwner(),
+				core.GetGithubRepoName(), prNumber, &github.IssueComment{Body: &commentBody})
+			if err != nil {
+				PrintFailure(nil)
+				return err
+			}
+			PrintSuccess()
+			return nil
+		},
+	}
+	return cmd
+}

--- a/core/github.go
+++ b/core/github.go
@@ -16,6 +16,7 @@ type GhPullRequest interface {
 
 type GhIssues interface {
 	ListByRepo(ctx context.Context, owner string, repo string, opts *github.IssueListByRepoOptions) ([]*github.Issue, *github.Response, error)
+	CreateComment(ctx context.Context, owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error)
 }
 
 type Gh interface {

--- a/core/tests/testrepo.go
+++ b/core/tests/testrepo.go
@@ -198,6 +198,11 @@ func (m *IssuesMock) ListByRepo(ctx context.Context, owner string, repo string, 
 	return args.Get(0).([]*github.Issue), nil, args.Error(2)
 }
 
+func (m *IssuesMock) CreateComment(ctx context.Context, owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error) {
+	args := m.Mock.Called(ctx, owner, repo, comment)
+	return args.Get(0).(*github.IssueComment), nil, args.Error(2)
+}
+
 func (m *IssuesMock) CallListAndReturnPr(prNumber int) {
 	pr := github.Issue{
 		Number: &prNumber,


### PR DESCRIPTION
Add a simple `comment` sub-command which allows adding a top-level
(non-review) comment to a PR.

Based on extensive market research, it appears that there is are potential future customers of `opp` who rely on triggering CI and related workflows by adding top-level comments to a PRs.

In order to fulfill the mission of making it possible to never touch the PR UI in Github, this PR makes it possible to add (non-review) comments on PRs directly from the command line.