### PR TITLE
Wait 30 seconds for github to create merge commit.

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -5,12 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/cupcicm/opp/core"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/go-github/v56/github"
 	"github.com/urfave/cli/v2"
 )
+
+var ErrBeingEvaluated = errors.New("still being checked by github")
 
 type merger struct {
 	Repo         *core.Repo
@@ -28,19 +31,30 @@ func MergeCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Comman
 			}
 			merger := merger{Repo: repo, PullRequests: gh(cCtx.Context).PullRequests()}
 			ancestors := pr.AllAncestors()
+			if len(ancestors) >= 1 {
+				fmt.Printf("%s is not mergeable because it has unmerged dependent PRs.\n", pr.Url())
+				return fmt.Errorf("please merge %s first", ancestors[0].LocalBranch())
+			}
+			fmt.Print("Checking mergeability... ")
+			mergeableContext, cancel := context.WithTimeoutCause(
+				cCtx.Context, core.GetGithubTimeout(),
+				fmt.Errorf("merging too slow, increase github.timeout"),
+			)
+			isMergeable, err := merger.IsMergeable(mergeableContext, pr)
+			cancel()
+			if errors.Is(err, ErrBeingEvaluated) {
+				isMergeable, err = merger.WaitForMergeability(cCtx.Context, pr)
+			}
+			if !isMergeable {
+				PrintFailure(nil)
+				return cli.Exit(err, 1)
+			}
+			PrintSuccess()
 			mergeContext, cancel := context.WithTimeoutCause(
 				cCtx.Context, core.GetGithubTimeout(),
 				fmt.Errorf("merging too slow, increase github.timeout"),
 			)
 			defer cancel()
-			if len(ancestors) >= 1 {
-				fmt.Printf("%s is not mergeable because it has unmerged dependent PRs.\n", pr.Url())
-				return fmt.Errorf("please merge %s first", ancestors[0].LocalBranch())
-			}
-			isMergeable, err := merger.IsMergeable(mergeContext, pr)
-			if !isMergeable {
-				return cli.Exit(err, 1)
-			}
 			if err := merger.Merge(mergeContext, pr); err != nil {
 				return cli.Exit("could not merge", 1)
 			}
@@ -64,7 +78,7 @@ func (m *merger) IsMergeable(ctx context.Context, pr *core.LocalPr) (bool, error
 		return false, errors.New("already merged")
 	}
 	if githubPr.Mergeable == nil {
-		return false, errors.New("still being checked by github")
+		return false, ErrBeingEvaluated
 	}
 	switch *githubPr.MergeableState {
 	case "dirty":
@@ -80,6 +94,26 @@ func (m *merger) IsMergeable(ctx context.Context, pr *core.LocalPr) (bool, error
 	default:
 		return false, errors.New("not mergeable")
 	}
+}
+
+func (m *merger) WaitForMergeability(ctx context.Context, pr *core.LocalPr) (bool, error) {
+	t := time.NewTicker(time.Second * 2)
+	tenSeconds, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer t.Stop()
+	defer cancel()
+	for i := 0; i < 5; i++ {
+		select {
+		case <-t.C:
+			// Try again
+		case <-ctx.Done():
+			return false, ErrBeingEvaluated
+		}
+		mergeable, err := m.IsMergeable(tenSeconds, pr)
+		if mergeable || err != ErrBeingEvaluated {
+			return mergeable, err
+		}
+	}
+	return false, ErrBeingEvaluated
 }
 
 func (m *merger) Merge(ctx context.Context, pr *core.LocalPr) error {

--- a/cmd/merge_test.go
+++ b/cmd/merge_test.go
@@ -3,6 +3,7 @@ package cmd_test
 import (
 	"testing"
 
+	"github.com/cupcicm/opp/cmd"
 	"github.com/cupcicm/opp/core"
 	"github.com/cupcicm/opp/core/tests"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,35 @@ func TestMergeKeepsTrackOfAncestorTips(t *testing.T) {
 	pr3 := r.CreatePr(t, "HEAD", 3)
 	r.Repo.Checkout(pr2)
 
+	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeable(2, true)
+	r.GithubMock.PullRequestsMock.CallMerge(2, "8f4ca5d979bc19b7c836655a6432d690f78316af")
+
+	// Check that pr3 knows about the tip of its ancestor (pr2)
+	assert.Len(t, pr3.AncestorTips(), 1)
+	pr2Tip := pr3.AncestorTips()[0]
+	assert.Equal(t, pr2Tip, core.Must(r.GetLocalTip(pr2)).Hash.String())
+
+	assert.Nil(t, r.Run("merge"))
+
+	// Assert that we have cleaned the local PR
+	assert.Len(t, core.Must(r.AllLocalPrs()), 1)
+
+	pr3.ReloadState()
+	assert.Len(t, pr3.AncestorTips(), 2)
+	assert.Contains(t, pr3.AncestorTips(), "8f4ca5d979bc19b7c836655a6432d690f78316af", pr2Tip)
+}
+
+func TestMergeWaitsForMergeability(t *testing.T) {
+	r := tests.NewTestRepo(t)
+	reset := cmd.SetShortMergeabilityIntervalForTests()
+	defer reset()
+
+	pr2 := r.CreatePr(t, "HEAD^", 2)
+	pr3 := r.CreatePr(t, "HEAD", 3)
+	r.Repo.Checkout(pr2)
+
+	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeabilityBeingEvaluated(2)
+	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeabilityBeingEvaluated(2)
 	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeable(2, true)
 	r.GithubMock.PullRequestsMock.CallMerge(2, "8f4ca5d979bc19b7c836655a6432d690f78316af")
 

--- a/core/tests/testrepo.go
+++ b/core/tests/testrepo.go
@@ -232,6 +232,19 @@ func (m *PullRequestsMock) CallGetAndReturnMergeable(prNumber int, mergeable boo
 		&pr, nil, nil,
 	).Once()
 }
+func (m *PullRequestsMock) CallGetAndReturnMergeabilityBeingEvaluated(prNumber int) {
+	reason := "clean"
+	state := "open"
+	pr := github.PullRequest{
+		Number:         &prNumber,
+		Mergeable:      nil,
+		MergeableState: &reason,
+		State:          &state,
+	}
+	m.On("Get", mock.Anything, "cupcicm", "opp", prNumber).Return(
+		&pr, nil, nil,
+	).Once()
+}
 
 func (m *PullRequestsMock) CallMerge(prNumber int, tip string) {
 	response := github.PullRequestMergeResult{


### PR DESCRIPTION
If you call `opp merge` right after someone else updated the branch
you are merging to, `opp` responds with "still being checked by
github" because github needs a few seconds to attempt to merge in the
background, to tell you if the PR is mergeable or not.

This change waits for this to happen for 30s.