### PR TITLE
Fixes a bug on `opp merge`

### DIFF
--- a/cmd/misc.go
+++ b/cmd/misc.go
@@ -46,10 +46,10 @@ func PrFromStringOrCurrentBranch(repo *core.Repo, str string) (*core.LocalPr, bo
 				return nil, false, cli.Exit(fmt.Errorf("%s is not a PR", str), 1)
 			}
 			pr = core.NewLocalPr(repo, prNumber)
-			headPr, headIsPr := repo.PrForHead()
-			if headIsPr && headPr.PrNumber == pr.PrNumber {
-				currentBranch = true
-			}
+		}
+		headPr, headIsPr := repo.PrForHead()
+		if headIsPr && headPr.PrNumber == pr.PrNumber {
+			currentBranch = true
 		}
 	}
 	return pr, currentBranch, nil


### PR DESCRIPTION
When merging the current branch, we need to checkout the main branch before
because deleting the branch we are currently sitting on is dangerous.

The check for "is head a PR" was not executed when running `opp merge pr/xxxx` but it's possible that you currently have  `pr/xxxx` checked out.