### PR TITLE
Adds a setting that allows opp to keep your master branch clean.

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -53,3 +53,7 @@ func GetGithubMergeMethod() string {
 func GetGithubTimeout() time.Duration {
 	return viper.GetDuration("github.timeout")
 }
+
+func GetCleanMaster() bool {
+	return viper.GetBool("opp.keep_master_clean")
+}

--- a/core/repo.go
+++ b/core/repo.go
@@ -244,6 +244,23 @@ func (r *Repo) TryRebaseOntoSilently(ctx context.Context, first plumbing.Hash, o
 	return false
 }
 
+func (r *Repo) TryLocalRebaseOntoSilently(
+	ctx context.Context,
+	first plumbing.Hash,
+	onto plumbing.Hash,
+) bool {
+	cmd := r.GitExec(ctx, "rebase --onto %s^ %s", onto.String(), first.String())
+	err := cmd.Run()
+	if err == nil {
+		return true
+	}
+	abort := r.GitExec(ctx, "rebase --abort")
+	if err := abort.Run(); err != nil {
+		panic(fmt.Errorf("tried to abort the rebase but failed: %w", err))
+	}
+	return false
+}
+
 func (r *Repo) TryRebaseBranchOnto(ctx context.Context, parent plumbing.Hash, onto Branch) bool {
 	ontoName := onto.LocalName()
 	if !onto.IsPr() {


### PR DESCRIPTION
When opp.keep_master_clean is set, if you create a PR, the commits
you have selected in the PR will be removed from the master branch.
This keeps the master branch clean.