### PR TITLE
Remove the "keep_master_clean" setting.

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -53,7 +53,3 @@ func GetGithubMergeMethod() string {
 func GetGithubTimeout() time.Duration {
 	return viper.GetDuration("github.timeout")
 }
-
-func GetCleanMaster() bool {
-	return viper.GetBool("opp.keep_master_clean")
-}


### PR DESCRIPTION
I don't like it. I feel that half of my PRs I want to "extract"
them to the PR branch so that they don't pollute the branch I am
working on, but the other half I want to keep on my current branch,
because I want to continue building commits on top of them.

So I propose to make it a command line flag instead. Spent a while
debating what the right word would be but I think "extract" makes sense ?