### PR TITLE
add story to pr title

### DIFF
--- a/core/story_service.go
+++ b/core/story_service.go
@@ -1,0 +1,46 @@
+package core
+
+import (
+	"regexp"
+)
+
+const storyPattern = `\[\w+[-_]\d+\]`
+
+type StoryService interface {
+    ExtractFromCommitMessages(messages []string) (string, bool)
+    StoryInString(str string) bool
+}
+
+func NewStoryService() (StoryService, error) {
+    re, err := regexp.Compile(storyPattern)
+    if err != nil {
+        return nil, err
+    }
+
+    return &storyService{
+        re: re,
+    }, nil
+}
+
+type storyService struct {
+    re *regexp.Regexp 
+}
+
+func (s *storyService) ExtractFromCommitMessages(messages []string) (string, bool) {
+	var found string
+	for _, m := range messages {
+		found = s.re.FindString(m)
+		if found == "" {
+			continue
+		} else {
+			return found, true
+		}
+	}
+
+	// pattern not found
+	return "", false
+}
+
+func (s *storyService) StoryInString(str string) bool {
+    return s.re.MatchString(str)
+}

--- a/core/story_service_test.go
+++ b/core/story_service_test.go
@@ -1,0 +1,112 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoryServiceExtractFromCommitMessages(t *testing.T) {
+    s, err := NewStoryService()
+    assert.NoError(t, err)
+
+    testCases := []struct{
+        name string
+        commitMessages []string
+        expectedFound bool
+        expectedStory string
+    }{
+        {
+            name: "single commit with story",
+            commitMessages: []string{"[ABC-345] fix that"},
+            expectedFound: true,
+            expectedStory: "[ABC-345]",
+        },
+        {
+            name: "single commit no story",
+            commitMessages: []string{"fix that"},
+            expectedFound: false,
+            expectedStory: "",
+        },
+        {
+            name: "several commits with one story",
+            commitMessages: []string{"[ABC-345] fix that", "do that"},
+            expectedFound: true,
+            expectedStory: "[ABC-345]",
+        },
+        {
+            name: "several commits with no story",
+            commitMessages: []string{"fix that", "do that"},
+            expectedFound: false,
+            expectedStory: "",
+        },
+        {
+            name: "several commits with several stories",
+            commitMessages: []string{"[ABC-345] fix that", "[DEF-678] do that"},
+            expectedFound: true,
+            expectedStory: "[ABC-345]",
+        },
+    }
+
+    for _, tc := range testCases {
+        t.Run(tc.name, func(t *testing.T){
+            value, found := s.ExtractFromCommitMessages(tc.commitMessages)
+            
+            if tc.expectedFound {
+                assert.True(t, found)
+            } else {
+                assert.False(t, found)
+            }
+            assert.Equal(t, tc.expectedStory, value)
+        })
+    }
+}
+
+func TestStoryServiceStoryInString(t *testing.T) {
+    s, err := NewStoryService()
+    assert.NoError(t, err)
+
+    testCases := []struct{
+        name string
+        message string
+        expectedFound bool
+    }{
+        {
+            name: "at the beginning of the commit message",
+            message: "[ABC-345] fix that",
+            expectedFound: true,
+        },
+        {
+            name: "in the middle of the commit message",
+            message: "fix [ABC-345] that",
+            expectedFound: true,
+        },
+        {
+            name: "at the end of the commit message",
+            message: "fix that [ABC-345]",
+            expectedFound: true,
+        },
+        {
+            name: "not in the commit message",
+            message: "fix that",
+            expectedFound: false,
+        },
+        {
+            name: "twice in the commit message",
+            message: "[ABC-345] fix that [DEF-678]",
+            expectedFound: true,
+        },
+    }
+
+    for _, tc := range testCases {
+        t.Run(tc.name, func(t *testing.T){
+            found := s.StoryInString(tc.message)
+            
+            if tc.expectedFound {
+                assert.True(t, found)
+            } else {
+                assert.False(t, found)
+            }
+        })
+    }
+}


### PR DESCRIPTION
This PR extracts the story from the commit messages and add it to the PR title.
It is a basic first implementation: 
- the story is identified based on a regexp
- if the regexp pattern is identified in the PR title, then nothing is added
- else, the regexp pattern is looked for in all the commits message, breaking the first time it is identified.