### PR TITLE
add story to pr title

### DIFF
--- a/cmd/pr_story_in_title_test.go
+++ b/cmd/pr_story_in_title_test.go
@@ -1,0 +1,143 @@
+package cmd_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cupcicm/opp/core"
+	"github.com/cupcicm/opp/core/tests"
+	"github.com/google/go-github/v56/github"
+)
+
+func TestPrTitle_StoryFromTitle(t *testing.T) {
+	remote := "cupcicm/pr/2"
+	base := "master"
+	body := ""
+	draft := false
+
+	testCases := []struct {
+		name           string
+		commitMessages []string
+		expectedTitle  string
+	}{
+		{
+			name:           "at the beginning of the title",
+			commitMessages: []string{"[ABC-456] c", "[ABC-123] fix that"},
+			expectedTitle:  "[ABC-123] fix that",
+		},
+		{
+			name:           "in the middle of the title",
+			commitMessages: []string{"[ABC-456] c", "fix [ABC-123] that"},
+			expectedTitle:  "fix [ABC-123] that",
+		},
+		{
+			name:           "at the end of the title",
+			commitMessages: []string{"[ABC-456] c", "fix that [ABC-123]"},
+			expectedTitle:  "fix that [ABC-123]",
+		},
+		{
+			name:           "not in the title",
+			commitMessages: []string{"[ABC-456] c", "fix that"},
+			expectedTitle:  "[ABC-456] c",
+		},
+		{
+			name:           "twice in the title",
+			commitMessages: []string{"[ABC-456] c", "[ABC-123] fix that [DEF-678]"},
+			expectedTitle:  "[ABC-123] fix that [DEF-678]",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tests.NewTestRepo(t)
+
+			r.Repo.GitExec(context.Background(), "checkout origin/master").Run()
+			r.Repo.GitExec(context.Background(), "checkout -b test_branch").Run()
+
+			wt := core.Must(r.Source.Worktree())
+
+			for _, commitMessage := range tc.commitMessages {
+				wt.Add("README.md")
+				r.Commit(commitMessage)
+			}
+
+			prDetails := github.NewPullRequest{
+				Title: &tc.expectedTitle,
+				Head:  &remote,
+				Base:  &base,
+				Body:  &body,
+				Draft: &draft,
+			}
+
+			r.CreatePrAssertPrDetails(t, "HEAD", 2, prDetails)
+		})
+	}
+}
+
+func TestPrTitle_StoryFromCommitMessages(t *testing.T) {
+	remote := "cupcicm/pr/2"
+	base := "master"
+	body := ""
+	draft := false
+
+	rawTitle := "my super long title" //Story not in rawTitle
+
+	testCases := []struct {
+		name           string
+		commitMessages []string
+		expectedTitle  string
+	}{
+		{
+			name:           "single other commit with story",
+			commitMessages: []string{"[ABC-345] fix that", rawTitle},
+			expectedTitle:  fmt.Sprintf("[ABC-345] %s", rawTitle),
+		},
+		{
+			name:           "single other commit without story",
+			commitMessages: []string{"fix that", rawTitle},
+			expectedTitle:  rawTitle,
+		},
+		{
+			name:           "several other commits with one story",
+			commitMessages: []string{"[ABC-345] fix that", "do that", rawTitle},
+			expectedTitle:  fmt.Sprintf("[ABC-345] %s", rawTitle),
+		},
+		{
+			name:           "several other commits without any story",
+			commitMessages: []string{"fix that", "do that", rawTitle},
+			expectedTitle:  rawTitle,
+		},
+		{
+			name:           "several other commits with several stories",
+			commitMessages: []string{"[ABC-345] fix that", "[DEF-678] do that", rawTitle},
+			expectedTitle:  fmt.Sprintf("[ABC-345] %s", rawTitle), // Take first occurence
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tests.NewTestRepo(t)
+
+			r.Repo.GitExec(context.Background(), "checkout origin/master").Run()
+			r.Repo.GitExec(context.Background(), "checkout -b test_branch").Run()
+
+			wt := core.Must(r.Source.Worktree())
+
+			for _, commitMessage := range tc.commitMessages {
+				wt.Add("README.md")
+				r.Commit(commitMessage)
+			}
+
+			prDetails := github.NewPullRequest{
+				Title: &tc.expectedTitle,
+				Head:  &remote,
+				Base:  &base,
+				Body:  &body,
+				Draft: &draft,
+			}
+
+			r.CreatePrAssertPrDetails(t, "HEAD", 2, prDetails)
+		})
+	}
+}

--- a/core/story_service.go
+++ b/core/story_service.go
@@ -1,0 +1,55 @@
+package core
+
+import (
+	"regexp"
+	"strings"
+)
+
+const storyPattern = `\[\w+[-_]\d+\]`
+
+func NewStoryService() (*StoryService, error) {
+	re, err := regexp.Compile(storyPattern)
+	if err != nil {
+		return nil, err
+	}
+
+	return &StoryService{
+		re: re,
+	}, nil
+}
+
+type StoryService struct {
+	re *regexp.Regexp
+}
+
+func (s *StoryService) AddToRawTitle(commitMessages []string, rawTitle string) string {
+	if s.storyInString(rawTitle) {
+		return rawTitle
+	}
+
+	story, found := s.extractFromCommitMessages(commitMessages)
+	if !found {
+		return rawTitle
+	}
+
+	return strings.Join([]string{story, rawTitle}, " ")
+}
+
+func (s *StoryService) extractFromCommitMessages(messages []string) (string, bool) {
+	var found string
+	for _, m := range messages {
+		found = s.re.FindString(m)
+		if found == "" {
+			continue
+		} else {
+			return found, true
+		}
+	}
+
+	// pattern not found
+	return "", false
+}
+
+func (s *StoryService) storyInString(str string) bool {
+	return s.re.MatchString(str)
+}

--- a/core/tests/testrepo.go
+++ b/core/tests/testrepo.go
@@ -144,6 +144,12 @@ func (r *TestRepo) CreatePr(t *testing.T, ref string, prNumber int, args ...stri
 	return r.AssertHasPr(t, prNumber)
 }
 
+func (r *TestRepo) CreatePrAssertPrDetails(t *testing.T, ref string, prNumber int, prDetails github.NewPullRequest, args ...string) *core.LocalPr {
+	pr := r.CreatePr(t, ref, prNumber, args...)
+	r.GithubMock.PullRequestsMock.AssertCalled(t, "Create", mock.Anything, "cupcicm", "opp", &prDetails)
+	return pr
+}
+
 func (r *TestRepo) MergePr(t *testing.T, pr *core.LocalPr) error {
 	tip := core.Must(r.GetLocalTip(pr))
 	r.GithubMock.PullRequestsMock.CallGetAndReturnMergeable(pr.PrNumber, true)


### PR DESCRIPTION
This PR extracts the story from the commit messages and adds it to the PR title.
It is a basic first implementation:

- the story is identified based on a regexp
- if the regexp pattern is identified in the PR title, then nothing is added
- else, the regexp pattern is searched in all commits message, stopping at the first occurence.