### PR TITLE
refactor: extract Story so that it can be used to enrich the Body.

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -337,12 +337,12 @@ func (c *create) Create(ctx context.Context, args *args) (*core.LocalPr, error) 
 }
 
 func (c *create) GetBodyAndTitle(commits []*object.Commit) (string, string) {
-	rawTitle, body := c.getRawBodyAndTitle(commits)
+	rawTitle, rawBody := c.getRawBodyAndTitle(commits)
 	commitMessages := make([]string, len(commits))
 	for i, c := range commits {
 		commitMessages[i] = c.Message
 	}
-	return c.StoryService.AddToRawTitle(commitMessages, rawTitle), body
+	return c.StoryService.EnrichBodyAndTitle(commitMessages, rawTitle, rawBody)
 }
 
 func (c *create) getRawBodyAndTitle(commits []*object.Commit) (string, string) {

--- a/core/story_service.go
+++ b/core/story_service.go
@@ -22,17 +22,24 @@ type StoryService struct {
 	re *regexp.Regexp
 }
 
-func (s *StoryService) AddToRawTitle(commitMessages []string, rawTitle string) string {
-	if s.storyInString(rawTitle) {
-		return rawTitle
+func (s *StoryService) EnrichBodyAndTitle(commitMessages []string, rawTitle, rawBody string) (title, body string) {
+	story, title := s.getStoryAndEnrichTitle(commitMessages, rawTitle)
+	return title, s.enrichBody(rawBody, story)
+}
+
+func (s *StoryService) getStoryAndEnrichTitle(commitMessages []string, rawTitle string) (story, title string) {
+	story, found := s.storyFromString(rawTitle)
+
+	if found {
+		return story, rawTitle
 	}
 
-	story, found := s.extractFromCommitMessages(commitMessages)
-	if !found {
-		return rawTitle
+	story, found = s.extractFromCommitMessages(commitMessages)
+	if found {
+		return story, strings.Join([]string{story, rawTitle}, " ")
 	}
 
-	return strings.Join([]string{story, rawTitle}, " ")
+	return "", rawTitle
 }
 
 func (s *StoryService) extractFromCommitMessages(messages []string) (string, bool) {
@@ -50,6 +57,12 @@ func (s *StoryService) extractFromCommitMessages(messages []string) (string, boo
 	return "", false
 }
 
-func (s *StoryService) storyInString(str string) bool {
-	return s.re.MatchString(str)
+func (s *StoryService) storyFromString(str string) (string, bool) {
+	result := s.re.FindString(str)
+	return result, result != ""
+}
+
+func (s *StoryService) enrichBody(rawBody, _ string) string {
+	// TODO(claire.philippe): to implement
+	return rawBody
 }


### PR DESCRIPTION
This is the first PR for a feature mentioned [here](https://github.com/cupcicm/opp/pull/160#issuecomment-2397865922), which consists in adding the link to the Story to the PR body.

Todo next: implement the `enrichBody` method.