### PR TITLE
[CUP-10] Adds the notion of a Tag for a branch.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,5 +61,13 @@
       "args": "up",
       "program": "opp.go"
     }
+    {
+      "name": "opp branch tag",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "args": "branch tag something",
+      "program": "opp.go"
+    }
   ]
 }

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -27,6 +27,7 @@ func MakeApp(out io.Writer, repo *core.Repo, gh func(context.Context) core.Gh) *
 			RebaseCommand(repo),
 			PushCommand(repo),
 			CommentCommand(repo, gh),
+			BranchCliCommand(repo),
 		},
 		Action: func(ctx *cli.Context) error {
 			// Called only if no subcommand match.

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -35,7 +35,7 @@ specified a different base for example.
 `)
 	DraftFlagUsage   = "Create a draft PR."
 	ExtractFlagUsage = strings.TrimSpace(`
-When set, tries to extract the commits used to create the PR from the current branch. 
+When set, tries to extract the commits used to create the PR from the current branch.
 This means that the current branch will not retain the commits you used to create the PR, they
 will be "moved" to the PR branch, and will not stay in your main branch.
 `)
@@ -152,6 +152,7 @@ type args struct {
 	Detached       bool
 	InitialBranch  core.Branch
 	Extract        bool
+	BranchTag      string
 }
 
 func (c *create) SanitizeArgs(cCtx *cli.Context) (*args, error) {

--- a/core/branch.go
+++ b/core/branch.go
@@ -21,12 +21,15 @@ type branch struct {
 	Repo  *Repo
 	Name  string
 	Local bool
+
+	state *BranchState
 }
 
 type Branch interface {
 	IsPr() bool
 	LocalName() string
 	RemoteName() string
+	Tag() string
 }
 
 func (b *LocalPr) ReloadState() {
@@ -55,6 +58,7 @@ func NewBranch(repo *Repo, name string) Branch {
 		Repo: repo,
 		Name: name,
 	}
+	branch.state = repo.StateStore().GetBranchState(&branch)
 	return &branch
 }
 
@@ -82,8 +86,16 @@ func (b *branch) RemoteName() string {
 	return b.Name
 }
 
+func (b *branch) Tag() string {
+	return b.state.Tag
+}
+
 func (b *LocalPr) Url() string {
 	return fmt.Sprintf("https://github.com/%s/pull/%d", GetGithubRepo(), b.PrNumber)
+}
+
+func (b *LocalPr) Tag() string {
+	return b.state.Tag
 }
 
 func (b *LocalPr) GetAncestor() (Branch, error) {

--- a/core/state.go
+++ b/core/state.go
@@ -15,6 +15,7 @@ type BranchState struct {
 		KnownTips []string
 	}
 	KnownTips []string
+	Tag       string
 }
 
 type StateStore struct {


### PR DESCRIPTION
- Linear [CUP-10](https:///issue/CUP-10)

This tag can be modified with "opp branch tag XXX"
and it can be used to tag a local branch with a
story. All PRs created from this local branch will
have the story.