### PR TITLE
simplify config

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -139,7 +139,7 @@ func PrCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Command {
 type create struct {
 	Repo         *core.Repo
 	Github       core.Gh
-	StoryService *story.StoryService
+	StoryService story.StoryService
 }
 
 type args struct {

--- a/core/config.go
+++ b/core/config.go
@@ -55,14 +55,10 @@ func GetGithubTimeout() time.Duration {
 	return viper.GetDuration("github.timeout")
 }
 
-func BodyEnrichmentEnabled() bool {
-	return viper.GetBool("story.enrichbody")
-}
-
 func GetStoryTool() string {
-	return viper.GetString("story.tool.name")
+	return viper.GetString("story.tool")
 }
 
 func GetStoryToolBaseUrl() string {
-	return viper.GetString("story.tool.baseurl")
+	return viper.GetString("story.enrichbodybaseurl")
 }

--- a/core/config.go
+++ b/core/config.go
@@ -10,7 +10,7 @@ import (
 func init() {
 	viper.SetDefault("github.merge.method", "rebase")
 	viper.SetDefault("github.timeout", 30*time.Second)
-	viper.SetDefault("story.enrichbody", false)
+	viper.SetDefault("story.enrich", true)
 }
 
 func GetGithubToken() string {
@@ -59,6 +59,10 @@ func GetStoryTool() string {
 	return viper.GetString("story.tool")
 }
 
-func GetStoryToolBaseUrl() string {
-	return viper.GetString("story.enrichbodybaseurl")
+func GetStoryToolUrl() string {
+	return viper.GetString("story.url")
+}
+
+func EnrichPrBodyWithStoryEnabled() bool {
+	return viper.GetBool("story.enrich")
 }

--- a/core/story/story_service.go
+++ b/core/story/story_service.go
@@ -12,13 +12,7 @@ import (
 
 const storyPattern = `\w+[-_]\d+`
 
-var (
-	urlPatterns = map[string]string{
-		"jira":   "https://%s/browse/%s",
-		"linear": "https://%s/issue/%s",
-	}
-	storyPatternWithBrackets = fmt.Sprintf(`\[%s\]`, storyPattern)
-)
+var storyPatternWithBrackets = fmt.Sprintf(`\[%s\]`, storyPattern)
 
 type StoryService struct {
 	re             *regexp.Regexp
@@ -113,7 +107,7 @@ func (s *StoryService) formatStoryInPRTitle(story string) string {
 }
 
 func (s *StoryService) enrichBody(rawBody, story string) (string, error) {
-	if story == "" || !core.BodyEnrichmentEnabled() {
+	if story == "" || core.GetStoryToolBaseUrl() == "" {
 		return rawBody, nil
 	}
 
@@ -131,17 +125,9 @@ func (s *StoryService) enrichBody(rawBody, story string) (string, error) {
 
 func (s *StoryService) formatBodyInPRTitle(story string) (string, error) {
 	tool := core.GetStoryTool()
-	urlTemplate, ok := urlPatterns[tool]
-	if !ok {
-		availableTools := []string{}
-		for availableTool := range urlPatterns {
-			availableTools = append(availableTools, availableTool)
-		}
-		return "", fmt.Errorf("tool set in config (%s) doesn't match possible values (%s)", tool, availableTools)
-	}
-
 	baseUrl := core.GetStoryToolBaseUrl()
-	url := fmt.Sprintf(urlTemplate, baseUrl, story)
+
+	url := fmt.Sprintf("%s/%s", baseUrl, story)
 
 	return fmt.Sprintf("%s [%s](%s)", cases.Title(language.Und).String(tool), story, url), nil
 }

--- a/core/tests/testrepo.go
+++ b/core/tests/testrepo.go
@@ -41,9 +41,8 @@ func setConfig() {
 	viper.Set("repo.branch", "master")
 	viper.Set("repo.github", "cupcicm/opp")
 	viper.Set("repo.remote", "origin")
-	viper.Set("story.enrichbody", true)
-	viper.Set("story.tool.name", "jira")
-	viper.Set("story.tool.baseurl", "my.base.url")
+	viper.Set("story.tool", "jira")
+	viper.Set("story.enrichbodybaseurl", "https://my.base.url/browse")
 }
 
 func NewTestRepo(t *testing.T) *TestRepo {

--- a/core/tests/testrepo.go
+++ b/core/tests/testrepo.go
@@ -42,7 +42,7 @@ func setConfig() {
 	viper.Set("repo.github", "cupcicm/opp")
 	viper.Set("repo.remote", "origin")
 	viper.Set("story.tool", "jira")
-	viper.Set("story.enrichbodybaseurl", "https://my.base.url/browse")
+	viper.Set("story.url", "https://my.base.url/browse")
 }
 
 func NewTestRepo(t *testing.T) *TestRepo {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d
 	golang.org/x/oauth2 v0.13.0
 	golang.org/x/sync v0.4.0
+	golang.org/x/text v0.13.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -56,7 +57,6 @@ require (
 	golang.org/x/mod v0.13.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect


### PR DESCRIPTION
The config format is now, for stories:

```
story:
    tool: linear
    url: https://full.base.url/issues
```

All these fields are required to make the Story features work. So: 
- if none are set: then no enrichment with Story
- if all are set: then enrichment with Story
- else: panic

In addition:
- another param can be added: `story.enrich` to disable the Body enrichment. By default it is set at true.
- opp also panics when the Story regexps don't compile