### PR TITLE
Use StoryFetcher

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -10,10 +10,11 @@ import (
 	"strings"
 
 	"github.com/cupcicm/opp/core"
+	"github.com/cupcicm/opp/core/story"
 	"github.com/urfave/cli/v2"
 )
 
-func MakeApp(out io.Writer, repo *core.Repo, gh func(context.Context) core.Gh) *cli.App {
+func MakeApp(out io.Writer, in io.Reader, repo *core.Repo, gh func(context.Context) core.Gh, sf func(string, string) story.StoryFetcher) *cli.App {
 	return &cli.App{
 		Name:  "opp",
 		Usage: "Create, update and merge Github pull requests from the command line.",
@@ -21,7 +22,7 @@ func MakeApp(out io.Writer, repo *core.Repo, gh func(context.Context) core.Gh) *
 			InitCommand(repo),
 			CleanCommand(repo, gh),
 			CloseCommand(repo, gh),
-			PrCommand(repo, gh),
+			PrCommand(in, repo, gh, sf),
 			MergeCommand(repo, gh),
 			StatusCommand(out, repo, gh),
 			RebaseCommand(repo),

--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -52,7 +53,7 @@ whether it reached the base branch or the tip of another PR first when walking b
 `)
 )
 
-func PrCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Command {
+func PrCommand(in io.Reader, repo *core.Repo, gh func(context.Context) core.Gh, sf func(string, string) story.StoryFetcher) *cli.Command {
 	cmd := &cli.Command{
 		Name:        "pr",
 		Aliases:     []string{"pull-request", "new"},
@@ -90,7 +91,7 @@ func PrCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Command {
 			if err != nil {
 				return err
 			}
-			pr := create{Repo: repo, Github: gh(cCtx.Context), StoryService: story.NewStoryService()}
+			pr := create{Repo: repo, Github: gh(cCtx.Context), StoryFetcher: sf}
 			args, err := pr.SanitizeArgs(cCtx)
 			if err != nil {
 				return err
@@ -103,7 +104,7 @@ func PrCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Command {
 				}
 				args = newArgs
 			}
-			localPr, err := pr.Create(cCtx.Context, args)
+			localPr, err := pr.Create(cCtx.Context, in, args)
 			if err != nil {
 				return err
 			}
@@ -135,7 +136,7 @@ func PrCommand(repo *core.Repo, gh func(context.Context) core.Gh) *cli.Command {
 type create struct {
 	Repo         *core.Repo
 	Github       core.Gh
-	StoryService story.StoryService
+	StoryFetcher func(string, string) story.StoryFetcher
 }
 
 type args struct {
@@ -311,11 +312,11 @@ func (c *create) RebasePrCommits(ctx context.Context, previousArgs *args) (*args
 	}, nil
 }
 
-func (c *create) Create(ctx context.Context, args *args) (*core.LocalPr, error) {
+func (c *create) Create(ctx context.Context, in io.Reader, args *args) (*core.LocalPr, error) {
 
 	// The first commit is the child-most one.
 	lastCommit := args.Commits[0].Hash
-	title, body, err := c.GetBodyAndTitle(args.Commits)
+	title, body, err := c.GetBodyAndTitle(ctx, in, args.Commits)
 	if err != nil {
 		return nil, fmt.Errorf("could not get the pull request body and title: %w", err)
 	}
@@ -336,13 +337,14 @@ func (c *create) Create(ctx context.Context, args *args) (*core.LocalPr, error) 
 	return localPr, err
 }
 
-func (c *create) GetBodyAndTitle(commits []*object.Commit) (string, string, error) {
+func (c *create) GetBodyAndTitle(ctx context.Context, in io.Reader, commits []*object.Commit) (string, string, error) {
 	rawTitle, rawBody := c.getRawBodyAndTitle(commits)
 	commitMessages := make([]string, len(commits))
 	for i, c := range commits {
 		commitMessages[i] = c.Message
 	}
-	title, body, err := c.StoryService.EnrichBodyAndTitle(commitMessages, rawTitle, rawBody)
+	storyService := story.NewStoryService(c.StoryFetcher, in)
+	title, body, err := storyService.EnrichBodyAndTitle(ctx, commitMessages, rawTitle, rawBody)
 	if err != nil {
 		return "", "", fmt.Errorf("could not enrich the PR with the Story: %w", err)
 	}

--- a/core/config.go
+++ b/core/config.go
@@ -66,3 +66,7 @@ func GetStoryToolUrl() string {
 func EnrichPrBodyWithStoryEnabled() bool {
 	return viper.GetBool("story.enrich")
 }
+
+func GetStoryToolToken() string {
+	return viper.GetString("story.token")
+}

--- a/core/story/story_fetcher.go
+++ b/core/story/story_fetcher.go
@@ -12,3 +12,12 @@ type Story struct {
 type StoryFetcher interface {
 	FetchInProgressStories(context.Context) ([]Story, error)
 }
+
+func NewStoryFetcher(tool, token string) StoryFetcher {
+	switch tool {
+	case "linear":
+		return NewLinearStoryFetcher(token)
+	default:
+		panic("Story tool not supported to fetch stories")
+	}
+}

--- a/core/tests/testrepo.go
+++ b/core/tests/testrepo.go
@@ -1,7 +1,9 @@
 package tests
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/cupcicm/opp/cmd"
 	"github.com/cupcicm/opp/core"
+	"github.com/cupcicm/opp/core/story"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -28,12 +31,14 @@ type Paths struct {
 
 type TestRepo struct {
 	*core.Repo
-	Source     *git.Repository
-	GithubRepo *git.Repository
-	Paths      Paths
-	GithubMock *GithubMock
-	App        *cli.App
-	Out        *strings.Builder
+	Source           *git.Repository
+	GithubRepo       *git.Repository
+	Paths            Paths
+	GithubMock       *GithubMock
+	StoryFetcherMock *StoryFetcherMock
+	App              *cli.App
+	Out              *strings.Builder
+	In               *bytes.Buffer
 }
 
 func setConfig() {
@@ -43,6 +48,7 @@ func setConfig() {
 	viper.Set("repo.remote", "origin")
 	viper.Set("story.tool", "linear")
 	viper.Set("story.url", "https://my.base.url/browse")
+	viper.Set("story.token", "my token")
 }
 
 func NewTestRepo(t *testing.T) *TestRepo {
@@ -60,7 +66,9 @@ func NewTestRepo(t *testing.T) *TestRepo {
 		PullRequestsMock: &PullRequestsMock{},
 		IssuesMock:       &IssuesMock{},
 	}
+	storyFetcherMock := &StoryFetcherMock{}
 	var out strings.Builder
+	var in bytes.Buffer
 	testRepo := TestRepo{
 		Source:     source,
 		GithubRepo: github,
@@ -69,10 +77,14 @@ func NewTestRepo(t *testing.T) *TestRepo {
 			Source:      sourcePath,
 			Destination: destPath,
 		},
-		GithubMock: mock,
-		Out:        &out,
-		App: cmd.MakeApp(&out, repo, func(context.Context) core.Gh {
+		GithubMock:       mock,
+		StoryFetcherMock: storyFetcherMock,
+		Out:              &out,
+		In:               &in,
+		App: cmd.MakeApp(&out, &in, repo, func(context.Context) core.Gh {
 			return mock
+		}, func(string, string) story.StoryFetcher {
+			return storyFetcherMock
 		}),
 	}
 	testRepo.PrepareSource()
@@ -139,15 +151,28 @@ func (r *TestRepo) AssertHasPr(t *testing.T, n int) *core.LocalPr {
 }
 
 func (r *TestRepo) CreatePr(t *testing.T, ref string, prNumber int, args ...string) *core.LocalPr {
+	return r.CreatePrWithStories(t, ref, prNumber, []story.Story{}, false, "", args...)
+}
+
+func (r *TestRepo) CreatePrWithStories(t *testing.T, ref string, prNumber int, stories []story.Story, errStories bool, selectedStory string, args ...string) *core.LocalPr {
 	r.GithubMock.IssuesMock.CallListAndReturnPr(prNumber - 1)
 	r.GithubMock.PullRequestsMock.CallCreate(prNumber)
-
+	r.StoryFetcherMock.CallFetchInProgressStories(stories, errStories)
+	if !errStories && len(stories) > 0 {
+		r.In.Write([]byte(fmt.Sprintf("%s\n", selectedStory)))
+	}
 	r.Run("pr", append(args, ref)...)
 	return r.AssertHasPr(t, prNumber)
 }
 
 func (r *TestRepo) CreatePrAssertPrDetails(t *testing.T, ref string, prNumber int, prDetails github.NewPullRequest, args ...string) *core.LocalPr {
 	pr := r.CreatePr(t, ref, prNumber, args...)
+	r.GithubMock.PullRequestsMock.AssertCalled(t, "Create", mock.Anything, "cupcicm", "opp", &prDetails)
+	return pr
+}
+
+func (r *TestRepo) CreatePrAssertPrDetailsWithStories(t *testing.T, ref string, prNumber int, stories []story.Story, errStories bool, selectedStory string, prDetails github.NewPullRequest, args ...string) *core.LocalPr {
+	pr := r.CreatePrWithStories(t, ref, prNumber, stories, errStories, selectedStory, args...)
 	r.GithubMock.PullRequestsMock.AssertCalled(t, "Create", mock.Anything, "cupcicm", "opp", &prDetails)
 	return pr
 }
@@ -266,4 +291,22 @@ func (m *PullRequestsMock) CallMerge(prNumber int, tip string) {
 	m.On("Merge", mock.Anything, "cupcicm", "opp", prNumber, "", mock.Anything).Return(
 		&response, nil, nil,
 	).Once()
+}
+
+type StoryFetcherMock struct {
+	mock.Mock
+}
+
+func (s *StoryFetcherMock) FetchInProgressStories(ctx context.Context) ([]story.Story, error) {
+	args := s.Mock.Called(ctx)
+	return args.Get(0).([]story.Story), args.Error(1)
+}
+
+func (s *StoryFetcherMock) CallFetchInProgressStories(stories []story.Story, fetchError bool) {
+	var err error
+	if fetchError {
+		err = errors.New("Story fetch error")
+	}
+
+	s.On("FetchInProgressStories", mock.Anything).Return(stories, err).Once()
 }

--- a/opp.go
+++ b/opp.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cupcicm/opp/cmd"
 	"github.com/cupcicm/opp/core"
+	"github.com/cupcicm/opp/core/story"
 	"github.com/spf13/viper"
 )
 
@@ -21,6 +22,10 @@ func gh(ctx context.Context) core.Gh {
 	return core.NewClient(ctx)
 }
 
+func sf(tool, token string) story.StoryFetcher {
+	return story.NewStoryFetcher(tool, token)
+}
+
 func main() {
 	repo := core.Current()
 	viper.AddConfigPath(repo.DotOpDir())
@@ -29,7 +34,7 @@ func main() {
 	viper.SetConfigType("yaml")
 	viper.ReadInConfig()
 
-	root := cmd.MakeApp(os.Stdout, repo, gh)
+	root := cmd.MakeApp(os.Stdout, os.Stdin, repo, gh, sf)
 	ctx, cancel := CommandContext()
 	if !repo.OppEnabled() && (len(os.Args) != 2 || os.Args[1] != "init") {
 		fmt.Println("Please run opp init first")


### PR DESCRIPTION
This PR uses the StoryFetcher to fetch in progress stories. It works only with Linear at the moment. Fetching Stories from Jira will be done in another PR.

A Personal API key has to be created and added to the opp config. The config for stories now looks like:

```
story:
    tool: linear
    url: https://full_url
    token: linear_personal_api_key
```