### PR TITLE
fix: --draft flag works when creating a PR with rebase

### DIFF
--- a/cmd/pr.go
+++ b/cmd/pr.go
@@ -301,15 +301,15 @@ func (c *create) RebasePrCommits(ctx context.Context, previousArgs *args) (*args
 			headCommit, core.GetRemoteName(), core.GetBaseBranch(),
 		), 1)
 	}
-	return &args{
-		AncestorBranch: ancestor,
-		Commits:        commits,
-		Detached:       previousArgs.Detached,
-		InitialBranch:  previousArgs.InitialBranch,
-		NeedsRebase:    false,
-		CheckoutPr:     true,
-		Extract:        previousArgs.Extract,
-	}, nil
+
+	// make a deep copy of previous args
+	newArgs := *previousArgs
+	newArgs.AncestorBranch = ancestor
+	newArgs.Commits = commits
+	newArgs.NeedsRebase = false
+	newArgs.CheckoutPr = true
+
+	return &newArgs, nil
 }
 
 func (c *create) Create(ctx context.Context, in io.Reader, args *args) (*core.LocalPr, error) {

--- a/cmd/pr_test.go
+++ b/cmd/pr_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/cupcicm/opp/core"
 	"github.com/cupcicm/opp/core/tests"
+	"github.com/google/go-github/v56/github"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -67,6 +68,34 @@ func TestCanSetAncestor(t *testing.T) {
 
 	r.CreatePr(t, "HEAD^", 2)
 	rebasedOnMaster := r.CreatePr(t, "HEAD", 3, "--base", "2")
+
+	assert.True(t, rebasedOnMaster.StateIsLoaded())
+	ancestor, err := rebasedOnMaster.GetAncestor()
+	if assert.Nil(t, err) {
+		assert.Equal(t, "pr/2", ancestor.LocalName())
+	}
+}
+
+func TestCanSetAncestorWithDraft(t *testing.T) {
+	r := tests.NewTestRepo(t)
+
+	r.CreatePr(t, "HEAD^", 2)
+
+	draft := true
+	remote := "cupcicm/pr/3"
+	base := "cupcicm/pr/2"
+	title := "4"
+	body := ""
+
+	prDetails := github.NewPullRequest{
+		Title: &title,
+		Head:  &remote,
+		Base:  &base,
+		Body:  &body,
+		Draft: &draft,
+	}
+
+	rebasedOnMaster := r.CreatePrAssertPrDetails(t, "HEAD", 3, prDetails, "--base", "2", "--draft")
 
 	assert.True(t, rebasedOnMaster.StateIsLoaded())
 	ancestor, err := rebasedOnMaster.GetAncestor()


### PR DESCRIPTION
When creating a PR with a rebase (e.g. `opp pr -i` or `opp pr --base xxx`), the `--draft` flag doesn't work.
This is because the value of `--draft` was not taken from the previous Args when building the new Args.

This PR makes a deep copy of the args in order to make sure that the previous Args are taken into account.